### PR TITLE
create.sql変更に伴うバックエンドコードの見直し

### DIFF
--- a/todo/DB設計.txt
+++ b/todo/DB設計.txt
@@ -35,8 +35,9 @@ create table `project`(
 
 create table `task`(
   `task_id` int(11) AUTO_INCREMENT NOT NULL PRIMARY KEY,
-  `project_id` int(11),
+  `project_id` int(11) NOT NULL,
   `task_value` varchar(30),
   `completetion_date` date,
-  `task_status` int(1)
+  `task_status` int(1),
+  FOREIGN KEY `fk_project_id`(`project_id`) REFERENCES `project`(`project_id`) ON DELETE CASCADE ON UPDATE CASCADE
 );

--- a/todo/create.sql
+++ b/todo/create.sql
@@ -6,8 +6,9 @@ create table `project`(
 
 create table `task`(
   `task_id` int(11) AUTO_INCREMENT NOT NULL PRIMARY KEY,
-  `project_id` int(11),
+  `project_id` int(11) NOT NULL,
   `task_value` varchar(30),
   `completetion_date` date,
-  `task_status` int(1)
+  `task_status` int(1),
+  FOREIGN KEY `fk_project_id`(`project_id`) REFERENCES `project`(`project_id`) ON DELETE CASCADE ON UPDATE CASCADE
 );

--- a/todo/srcFolder/SQL.php
+++ b/todo/srcFolder/SQL.php
@@ -127,22 +127,6 @@ class SQL
         $pdo = null;
     }
 
-    //プロジェクト削除時、該当するタスクの全削除
-    public static function deleteProjectTasks($id)
-    {
-        try {
-            $pdo = new PDO(DB::dsn, DB::username, DB::password);
-            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-            $sql = 'DELETE FROM `task` WHERE `project_id`= :id';
-            $stmt = $pdo->prepare($sql);
-            $stmt->execute(array(':id' => $id));
-        } catch (PDOException $e) {
-            die();
-        }
-
-        $pdo = null;
-    }
-
     //プロジェクト選択時、タスクのINSERT
     public static function insertTaskToProject($project_id, $task_value, $completetion_date)
     {

--- a/todo/srcFolder/post.php
+++ b/todo/srcFolder/post.php
@@ -169,8 +169,6 @@ function deleteProject()
     $project_id = $_POST['project_id'];
     //データの削除
     SQL::deleteProject(DB::h($project_id));
-    //該当タスクの全削除
-    SQL::deleteProjectTasks(DB::h($project_id));
     header("Content-type: application/json; charset=UTF-8");
     echo json_encode($_POST['project_id']);
     exit;


### PR DESCRIPTION
create.sqlにおいて、taskテーブルの外部キー制約を追加してみました。
外部キー制約を追加することで、projectテーブルのレコードが削除された場合にMySQL側でtaskテーブルの同一project_idのレコードを削除するようにしています。また、バックエンドコード(PHP)の一部について削除のみ行っています。

※create.sqlのCREATE TABLE文を変更していますが、すでにテーブル作成済みの方向けにALTER TABLE文を提供した方が良い場合はマージしないようお願い致します。

ご確認お願い致します。問題が無ければ、マージして頂ければと思います。