### PR TITLE
プロジェクト追加時の特殊文字扱いを修正

### DIFF
--- a/todo/srcFolder/post.php
+++ b/todo/srcFolder/post.php
@@ -146,7 +146,7 @@ function insertProject()
 {
     $data = $_POST['value'];
     //プロジェクトの追加SQL送信
-    SQL::insertProject(DB::h($data));
+    SQL::insertProject($data);
     //追加後のプロジェクトを取得
     $new_project_stmt = SQL::selectProject();
 


### PR DESCRIPTION
大変恐縮ですが、プロジェクト追加時に特殊文字がHTML エンティティ("<"→"\&lt;"など)に置き換わってしまう現象が発生しましたので、修正を行いました。
DBのprojectテーブルには、HTMLエンティティに置き換える前のプロジェクト名を追加するようにしています。
<img width="357" alt="fix_insert_project" src="https://user-images.githubusercontent.com/90094327/132112370-b3ad0046-aab3-42f3-98e6-89abf152664d.png">

お手数をお掛け致しますが、ご確認のほど、よろしくお願い致します。