### PR TITLE
cookie(todoSoundType)の有効期限を修正

### DIFF
--- a/todo/srcFolder/main.js
+++ b/todo/srcFolder/main.js
@@ -191,7 +191,7 @@ function changeSound(){
             break;
     }
     //cookieの保存
-    document.cookie = `todoSoundType=${soundNum}`;
+    document.cookie = `todoSoundType=${soundNum}; expires=Fri, 31 Dec 9999 23:59:59 GMT`;
 }
 
 /**


### PR DESCRIPTION
大変恐縮ですが、cookie(todoSoundType)の有効期限が現在のセッションのみ(※)となっていたため、修正を行いました。
※：ブラウザを完全に終了させてしまうとセッション消滅となり、保存したcookieのキーが無効になっておりました。
![image](https://user-images.githubusercontent.com/90094327/134800399-e6d00698-670a-4a02-90cb-f3614da92ddc.png)

少々荒い形になりますが、有効期限をFri, 31 Dec 9999 23:59:59 GMTに修正致しました。
お手数をお掛け致しますが、ご確認のほど、よろしくお願い致します。