### PR TITLE
SQL.php selectTaskFromProject() -> selectTasks()変更

### DIFF
--- a/todo/srcFolder/SQL.php
+++ b/todo/srcFolder/SQL.php
@@ -275,12 +275,35 @@ EOF;
         $pdo = null;
     }
 
-    //プロジェクト選択時、タスクのSELECT
-    public static function selectTaskFromProject($project_id)
+    //タスクのSELECT
+    public static function selectTasks($project_id, $date_from, $date_to, $status)
     {
         try {
             $pdo = new PDO(DB::dsn, DB::username, DB::password);
             $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $sqlWhere = "";
+            $array = array();
+            if($project_id != null && strlen($project_id) > 0){
+                if(strlen($sqlWhere) > 0) $sqlWhere .= "AND";
+                $sqlWhere .= " `project_id` = :project_id ";
+                $array[":project_id"] = $project_id;
+            }
+            if($date_from != null && strlen($date_from) > 0){
+                if(strlen($sqlWhere) > 0) $sqlWhere .= "AND";
+                $sqlWhere .= " `completetion_date` >= STR_TO_DATE(:date_from, '%Y-%m-%d') ";
+                $array[":date_from"] = $date_from;
+            }
+            if($date_to != null && strlen($date_to) > 0){
+                if(strlen($sqlWhere) > 0) $sqlWhere .= "AND";
+                $sqlWhere .= " `completetion_date` <= STR_TO_DATE(:date_to, '%Y-%m-%d') ";
+                $array[":date_to"] = $date_to;
+            }
+            if($status != null && strlen($status) > 0){
+                if(strlen($sqlWhere) > 0) $sqlWhere .= "AND";
+                $sqlWhere .= " `status` = :status ";
+                $array[":status"] = $status;
+            }
+            if (strlen($sqlWhere) > 0) $sqlWhere = "WHERE" . $sqlWhere;
             $sql = <<< EOF
 SELECT
  `task_id`,
@@ -290,13 +313,13 @@ SELECT
  `task_status`
 FROM
  `task`
-WHERE
- `project_id` = :project_id
+{$sqlWhere}
 ORDER BY
- `completetion_date`
+ `completetion_date`,
+ `task_id`
 EOF;
             $stmt = $pdo->prepare($sql);
-            $stmt->execute(array(':project_id' => $project_id));
+            $stmt->execute($array);
         } catch (PDOException $e) {
             die();
         }

--- a/todo/srcFolder/main.js
+++ b/todo/srcFolder/main.js
@@ -363,8 +363,8 @@ function displayTaskOfSelectProject(project_id){
         {
             type: "POST",
             data:{
-                value: project_id,
-                todo: "selectProjectTask"
+                project_id: project_id,
+                todo: "selectTasks"
             },
             dataType: "json"
         }

--- a/todo/srcFolder/post.php
+++ b/todo/srcFolder/post.php
@@ -20,8 +20,8 @@ switch ($_POST['todo']) {
     case "selectProject":
         selectProject();
         break;
-    case "selectProjectTask":
-        selectProjectTask();
+    case "selectTasks":
+        selectTasks();
         break;
     case "deleteTask":
         deleteTask();
@@ -96,7 +96,7 @@ function updateTaskStatus()
     if($project_id === null){
         $data = "notProject";
     }else{
-        $data = SQL::selectTaskFromProject(DB::h($project_id));
+        $data = SQL::selectTasks($project_id, null, null, null);
     }
 
     header("Content-type: application/json; charset=UTF-8");
@@ -115,7 +115,7 @@ function deleteTask()
     if($project_id === null){
         $data = "notProject";
     }else{
-        $data = SQL::selectTaskFromProject(DB::h($project_id));
+        $data = SQL::selectTasks($project_id, null, null, null);
     }
     header("Content-type: application/json; charset=UTF-8");
     echo json_encode($data);
@@ -131,12 +131,15 @@ function selectProject()
     exit;
 }
 
-//プロジェクト選択時、該当プロジェクトのタスク一覧を返す
-function selectProjectTask()
+//タスク一覧を返す
+function selectTasks()
 {
-    $project_id = $_POST['value'];
+    $project_id = isset($_POST['project_id']) ? $_POST['project_id'] : null;
+    $date_from = isset($_POST['date_from']) ? $_POST['date_from'] : null;
+    $date_to = isset($_POST['date_to']) ? $_POST['date_to'] : null;
+    $status = isset($_POST['status']) ? $_POST['status'] : null;
     //該当タスク取得
-    $new_tasks_row = SQL::selectTaskFromProject(DB::h($project_id));
+    $new_tasks_row = SQL::selectTasks($project_id, $date_from, $date_to, $status);
     //新しいタスクのデータを返す
     header("Content-type: application/json; charset=UTF-8");
     echo json_encode($new_tasks_row);
@@ -188,7 +191,7 @@ function insertTaskToProject()
     //タスクの追加
     SQL::insertTaskToProject(DB::h($_POST['project_id']), DB::h($_POST['task_value']), DB::h($_POST['completetion_date']));
     //タスク追加後のプロジェクト内のタスク取得
-    $data = SQL::selectTaskFromProject($_POST['project_id']);
+    $data = SQL::selectTasks($_POST['project_id'], null, null, null);
     header("Content-type: application/json; charset=UTF-8");
     echo json_encode($data);
     exit;


### PR DESCRIPTION
大変恐縮ですが、SQL.phpのselectTaskFromProject(引数なし)メソッドをselectTasks(引数あり)メソッドに変更してみました。
この変更に伴い、main.jsファイル、post.phpファイルを変更しております。

お手数をお掛け致しますが、ご確認のほど、よろしくお願い致します。

当Pull requestがマージされた場合は、SQL.phpの以下メソッド呼び出しをselectTasksメソッドに統合する予定です。
1. selectTaskUntilYesterday
2. selectCompletedTasks
3. selectTaskFromThatDay
4. selectTaskFromOneDay