### PR TITLE
プロジェクト名変更対応(#29)

### DIFF
--- a/todo/srcFolder/SQL.php
+++ b/todo/srcFolder/SQL.php
@@ -89,22 +89,34 @@ EOF;
         $pdo = null;
     }
 
-    //プロジェクトの色変更
-    public static function updateProjectColor($project_id, $color)
+    //プロジェクト内容更新
+    public static function updateProject($project_id, $project_name, $color)
     {
         try {
             $pdo = new PDO(DB::dsn, DB::username, DB::password);
             $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $sqlSet = "";
+            $array = array(':project_id' => $project_id);
+            if($project_name != null && strlen($project_name) > 0){
+                if(strlen($sqlSet) > 0) $sqlSet .= ",";
+                $sqlSet .= " `project_name` = :project_name ";
+                $array[":project_name"] = $project_name;
+            }
+            if($color != null && strlen($color) > 0){
+                if(strlen($sqlSet) > 0) $sqlSet .= ",";
+                $sqlSet .= " `color` = :color ";
+                $array[":color"] = $color;
+            }
             $sql = <<< EOF
 UPDATE
  `project`
 SET
- `color` = :color
+{$sqlSet}
 WHERE
  `project_id` = :project_id
 EOF;
             $stmt = $pdo->prepare($sql);
-            $stmt->execute(array(':project_id' => $project_id, ':color' => $color));
+            $stmt->execute($array);
         } catch (PDOException $e) {
             die();
         }

--- a/todo/srcFolder/main.css
+++ b/todo/srcFolder/main.css
@@ -43,23 +43,6 @@
   transform: scale(1.4);
 }
 
-.main-column-today i {
-  color: #66cdaa;
-}
-.main-column-tomorrow i {
-  color: #ffa500;
-}
-.main-column-later i {
-  color: #1e90ff;
-}
-.main-column-completed i {
-  color: #777;
-}
-.main-column-incomplete i {
-  /* color: #ffd700; */
-  color: #ff5416cc;
-}
-
 .counts {
   margin-left: auto;
   margin-right: 20px;
@@ -77,8 +60,10 @@
 .main-column-projects-project i {
   margin: 0px 5px;
 }
-.main-column-projects-project p {
-  width: 170px;
+.main-column-projects-project .name,
+.main-column-projects-project .rename {
+  width: 100%;
+  box-sizing: border-box;
 }
 .main-column-add_project {
   display: flex;

--- a/todo/srcFolder/post.php
+++ b/todo/srcFolder/post.php
@@ -11,8 +11,8 @@ switch ($_POST['todo']) {
     case "deleteProject":
         deleteProject();
         break;
-    case "updateProjectColor":
-        updateProjectColor();
+    case "updateProject":
+        updateProject();
         break;
     case "insertTaskToProject":
         insertTaskToProject();
@@ -55,16 +55,10 @@ function updateTaskStatus()
 //タスクの削除
 function deleteTask()
 {
-    $project_id = $_POST['project_id'];
     $task_id = $_POST['task_id'];
     //データの削除
-    SQL::deleteTask(DB::h($task_id));
+    $data = SQL::deleteTask($task_id);
     //更新後のタスクの取得
-    if($project_id === null){
-        $data = "notProject";
-    }else{
-        $data = SQL::selectTasks($project_id, null, null, null);
-    }
     header("Content-type: application/json; charset=UTF-8");
     echo json_encode($data);
     exit;
@@ -120,13 +114,14 @@ function deleteProject()
     exit;
 }
 
-//プロジェクトの色変更
-function updateProjectColor()
+//プロジェクト内容更新
+function updateProject()
 {
     $project_id = $_POST['project_id'];
-    $color = $_POST['color'];
+    $project_name = isset($_POST['project_name']) ? $_POST['project_name'] : null;
+    $color = isset($_POST['color']) ? $_POST['color'] : null;
     //データの更新
-    $count = SQL::updateProjectColor($project_id, $color);
+    $count = SQL::updateProject($project_id, $project_name, $color);
 
     header("Content-type: application/json; charset=UTF-8");
     echo json_encode($count);


### PR DESCRIPTION
大変恐縮ですが、Issue #29 についてプロジェクト名変更の試作を行いました。
1. プロジェクト名をダブルクリック
2. プロジェクトをクリックして選択後、プロジェクト名をクリック

1, 2のいずれかの操作を行うことでプロジェクト名の入力ができるようになっております。

プロジェクト追加時と同様にEnterキーで確定となります。

また、今回の対応によりタスク一覧のタイトル(todo_title)がデータバインドで表示されるようになりました。
class AbstractColumn(コラム抽象クラス)を作成し、
1. 画面左上の「今日」「明日」「それ以降」「完了済み」「期限超過」をclass Column(コラムクラス)で表示
2. 画面右下のプロジェクト一覧をclass Project(プロジェクトクラス)で表示
といった形で対応を行っております。

お手数をお掛け致しますが、ご確認のほど、よろしくお願い致します。

(2021/10/19 13:19 追記)
当Pull Requestはプロジェクト名変更対応の1例です。
Issueに記載頂いておりました、プロジェクト追加のテキストボックスとの統合などは考慮しておりません。