### PR TITLE
doamomo:incomplete_task_count_add_inspection ブランチから doamomo:master へマ…

### DIFF
--- a/todo/srcFolder/index.php
+++ b/todo/srcFolder/index.php
@@ -24,7 +24,7 @@
                     <div class="column_box" data-bind="css: { selected_column: $root.selectedColumn() === $data }, click: clickColumn">
                         <i class="material-icons icon-column" data-bind="text: icon, style: { color: color }"></i>
                         <p data-bind="text: name"></p>
-                        <p class="counts"></p>
+                        <p class="counts" data-bind="text: countIncompleteTasks"></p>
                     </div>
                 </div>
                 <hr class="hr_gray">

--- a/todo/srcFolder/main.js
+++ b/todo/srcFolder/main.js
@@ -90,6 +90,7 @@ class Project extends AbstractColumn {
 class Column extends AbstractColumn {
     icon = '';
     type = '';
+    countIncompleteTasks = ko.observable();
     constructor(name, color, icon, type){
         super(name, color);
         this.icon = icon;


### PR DESCRIPTION
…ージ時における競合解決のサポート

2021/10/21 14:25 時点で、incomplete_task_count_add_inspection ブランチから master ブランチへマージした際に競合が発生します。

当Pull Requestは競合解決のサポートを行います。
競合が発生するファイルは以下の2ファイルとなっております。

1. todo/srcFolder/index.php
2. todo/srcFolder/main.js

Pull Request #30 にて画面左上の「今日」「明日」「それ以降」「完了済み」「期限超過」のそれぞれの項目について表示するための情報を ViewModelクラスのパブリックフィールドcolumnsに格納するようにしています。
その影響により、index.phpファイル上で`data-bind="foreach: columns"`という形で前述の5つの項目を表示するよう変更しています。
当Pull Requestでは、ColumnクラスにパブリックフィールドcountIncompleteTasksを追加して、これを用いて未完了タスク件数を表示するよう対応しています。

実際の未完了タスク件数を取得する処理は @doamomo 様の incomplete_task_count_add_inspection ブランチにて追加して頂きました、displayIncompleteTasks関数にて以下のように記述を変更して頂くことで件数表示することができます(「今日」の未完了タスク件数を表示する場合)。
`vm.columns[COLUMN_TYPE.TODAY].countIncompleteTasks(incompleteTasksCount[0]["count"]);`

お手数をお掛け致しますが、masterブランチへのマージで競合が発生した場合は上記のご対応をお願い致します。