### PR TITLE
スキン設定 背景画像をコピー＆ペーストで設定できるよう変更

### DIFF
--- a/todo/srcFolder/main.js
+++ b/todo/srcFolder/main.js
@@ -343,6 +343,30 @@ window.onload = function(){
             }
         }
     });
+    //貼り付け時の機能
+    document.body.addEventListener("paste", event =>{
+        if(event.clipboardData === null){
+            console.log("event.clipboardData === null");
+            return;
+        }
+
+        //ファイルデータが存在するか確認する
+        let index = -1;
+        for(let i=0; i<event.clipboardData.types.length; i++){
+            if(event.clipboardData.types[i] !== "Files" ||
+               !event.clipboardData.items[i].type.startsWith("image")){
+                continue;
+            }
+            index = i;
+            break;
+        }
+        if(index === -1){
+            return;
+        }
+
+        //背景画像変更(スキン設定)
+        readBackgroundImage(event.clipboardData.items[index].getAsFile());
+    });
 }
 
 /**
@@ -837,12 +861,18 @@ function updateBackgroundImage(imageData){
     });
 }
 function changeBackgroundImage(object, event){
+    readBackgroundImage(event.target.files[0]);
+}
+function readBackgroundImage(file){
+    if(file === null){
+        return;
+    }
     const reader = new FileReader();
     reader.onload = function(e){
         //スキン情報変更(背景画像)
         updateBackgroundImage(e.target.result);
     }
-    reader.readAsDataURL(event.target.files[0]);
+    reader.readAsDataURL(file);
 }
 
 //スキン初期設定


### PR DESCRIPTION
Issue https://github.com/doamomo/todoApp/issues/32#issuecomment-954585764 の @doamomo 様コメントを引用致します。

> （余談ですが、著作権に配慮してパブリックドメイン見ましたが、minimadonさんの使われていた少女の画像目立ちますね。私もDLしかけました）

大変恐縮ですが、PC環境のみとなりますが件名に記載の通り、「スキン設定にて背景画像をコピー＆ペーストで設定できるよう変更」致しました。
この対応で画像をDLしなくても背景画像を変更することが可能となります(そうじゃない)

下図の通りとなっております。
<img width="600" src="https://user-images.githubusercontent.com/90094327/139514854-db27011b-e69c-44da-ba4b-e9e59dbfe2f2.png">

<img height="600" src="https://user-images.githubusercontent.com/90094327/139515071-0e8b3dad-84fd-4f99-863c-23fd3252a8a9.png">

お手数をお掛け致しますが、ご確認のほど、よろしくお願い致します。