### PR TITLE
スキン設定 背景色透明度の設定不良を修正

### DIFF
--- a/todo/srcFolder/main.css
+++ b/todo/srcFolder/main.css
@@ -62,6 +62,7 @@
   display: flex;
   align-items: center;
   overflow: hidden;
+  background-color: #fff;
 }
 .main-column-projects-project i {
   margin: 0px 5px;

--- a/todo/srcFolder/main.js
+++ b/todo/srcFolder/main.js
@@ -83,7 +83,7 @@ class ViewModel {
  
     //背景画像
     imageFileMaxSize = ko.observable('0');
-    backgroundImage = ko.observable(null);
+    backgroundImage = ko.observable('');
 
     //フォント
     availableFontFamilies = [
@@ -238,19 +238,18 @@ class FontFamily {
 const vm = new ViewModel();
 vm.isMobile(navigator.userAgent.match(/iPhone|Android.+Mobile/));
 vm.backgroundImage.subscribe(function(newValue){
-    changeBackgroundColorAlpha(".header", newValue !== null ? 0.9375 : 1.0);
-    changeBackgroundColorAlpha(".settings", newValue !== null ? 0.9375 : 1.0);
-    changeBackgroundColorAlpha(".main", newValue !== null ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-column", newValue !== null ? 0.0 : 1.0);
-    changeBackgroundColorAlpha(".column_box", newValue !== null ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".selected_column", newValue !== null ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-column-projects-project", newValue !== null ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-todo", newValue !== null ? 0.0 : 1.0);
-    changeBackgroundColorAlpha(".main-todo-result", newValue !== null ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-todo-body-tasks-task", newValue !== null ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-todo-body-complete_task_button", newValue !== null ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-todo-body-complete_tasks", newValue !== null ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-todo-body-incomplete_tasks", newValue !== null ? 0.75 : 1.0);
+    changeBackgroundColorAlpha(".header", newValue !== '' ? 0.9375 : 1.0);
+    changeBackgroundColorAlpha(".settings", newValue !== '' ? 0.9375 : 1.0);
+    changeBackgroundColorAlpha(".main", newValue !== '' ? 0.75 : 1.0);
+    changeBackgroundColorAlpha(".main-column", newValue !== '' ? 0.0 : 1.0);
+    changeBackgroundColorAlpha(".column_box", newValue !== '' ? 0.75 : 1.0);
+    changeBackgroundColorAlpha(".selected_column", newValue !== '' ? 0.75 : 1.0);
+    changeBackgroundColorAlpha(".main-column-projects-project", newValue !== '' ? 0.75 : 1.0);
+    changeBackgroundColorAlpha(".main-todo", newValue !== '' ? 0.0 : 1.0);
+    changeBackgroundColorAlpha(".main-todo-result", newValue !== '' ? 0.75 : 1.0);
+    changeBackgroundColorAlpha(".main-todo-body-tasks-task", newValue !== '' ? 0.75 : 1.0);
+    changeBackgroundColorAlpha(".main-todo-body-complete_task_button", newValue !== '' ? 0.75 : 1.0);
+    changeBackgroundColorAlpha(".main-todo-body-complete_tasks, .main-todo-body-incomplete_tasks", newValue !== '' ? 0.75 : 1.0);
 });
 ko.applyBindings(vm);
 


### PR DESCRIPTION
Issue #32 より @doamomo 様のコメント( https://github.com/doamomo/todoApp/issues/32#issuecomment-955131854 )を引用致します。
> 細かい問題なのですが、適用画像を削除した際に、右側の背景が真っ白のままとなっております。
> 更新すれば直る問題ではありますが、こちら適用前の色に戻すことは可能でしょうか？

コメント頂きましてありがとうございます。

大変恐縮ですが、件名に記載の通り、「スキン設定の背景色透明度の設定不良を修正」致しました。
背景画像データの存在チェック不良が原因でした。''(ブランク)と比較すべきところをnullと比較しておりました。
修正前: `newValue !== null`
修正後: `newValue !== ''`

また、プロジェクト一覧の各プロジェクト背景色透明度が設定できていなかったため、プロジェクト名称が見づらい状況となっておりました。
こちらの修正も当Pull Requestに含まれております。下図のようになっております。

<img width="600" src="https://user-images.githubusercontent.com/90094327/139521600-d475ed53-d892-43f5-9321-126721f2694f.png">

お手数をお掛け致しますが、ご確認のほど、よろしくお願い致します。