### PR TITLE
タスク一覧ラベルのタップでプロジェクト色変更対応

### DIFF
--- a/todo/srcFolder/index.php
+++ b/todo/srcFolder/index.php
@@ -82,11 +82,19 @@
             </div>
             <div class="main-todo">
                 <div id="todo_title">
-                    <i class="material-icons darkmode-ignore" data-bind="
-                        css: { 'icon-column': selectedColumn() instanceof Column },
-                        style: { color: selectedColumn() !== null ? selectedColumn().color : 'black' },
-                        text: selectedColumn() !== null ? selectedColumn().icon : ''"></i><span data-bind="
-                        text: selectedColumn() !== null ? selectedColumn().name : 'プロジェクト未選択'"></span>
+                    <label data-bind="
+                        click: selectedColumn() instanceof Project ? function(){return true;} : function(){return false;}">
+                        <input type="color" class="color-picker" data-bind="
+                            css: {
+                                'color-picker' : !isMobile(),
+                                'color-picker-mobile' : isMobile()
+                            },
+                            value: selectedColumn() !== null ? selectedColumn().color : '',
+                            event: { change: changeProjectColor }"/>
+                        <i class="material-icons darkmode-ignore icon-column" data-bind="
+                            style: { color: selectedColumn() !== null ? selectedColumn().color : 'black' },
+                            text: selectedColumn() !== null ? selectedColumn().icon : ''"></i></label><span data-bind="
+                            text: selectedColumn() !== null ? selectedColumn().name : 'プロジェクト未選択'"/>
                 </div>
                 <div class="main-todo-result" data-bind="style: { marginLeft: isMobile() ? '0px' : '30px', width: isMobile() ? '100%' : '500px'}">
                     <div class="main-todo-result-incomplete" data-bind="style: { marginLeft: isMobile() ? '20%' : '130px'}">

--- a/todo/srcFolder/main.css
+++ b/todo/srcFolder/main.css
@@ -34,7 +34,7 @@
 }
 
 .selected_column {
-  background-color: #a8ffc0;
+  background-color: #a8ffc0 !important;
 }
 
 .icon-column {
@@ -43,6 +43,7 @@
   left: 0px;
   position: relative;
   transform: scale(1.4);
+  vertical-align: middle;
 }
 
 .counts {

--- a/todo/srcFolder/main.js
+++ b/todo/srcFolder/main.js
@@ -42,6 +42,21 @@ const TASK_STATUS = { COMPLETED: 0, INCOMPLETE: 1 };
 const DEFAULT_PROJECT_COLOR = "#777777";
 //デフォルトフォントファミリー
 const DEFAULT_FONT_FAMILY = "unset";
+//背景色透過率設定(背景画像ありの場合)
+const BACKGROUND_COLOR_ALPHA = [
+    { selector: ".header", alpha: 0.9375 },
+    { selector: ".settings", alpha: 0.9375 },
+    { selector: ".main", alpha: 0.75 },
+    { selector: ".main-column", alpha: 0.0 },
+    { selector: ".column_box", alpha: 0.75 },
+    { selector: ".selected_column", alpha: 0.75, important: true },
+    { selector: ".main-column-projects-project", alpha: 0.75 },
+    { selector: ".main-todo", alpha: 0.0 },
+    { selector: ".main-todo-result", alpha: 0.75 },
+    { selector: ".main-todo-body-tasks-task", alpha: 0.75 },
+    { selector: ".main-todo-body-complete_task_button", alpha: 0.75 },
+    { selector: ".main-todo-body-complete_tasks, .main-todo-body-incomplete_tasks", alpha: 0.75 }
+];
 
 //ビューモデルクラス
 class ViewModel {
@@ -238,18 +253,14 @@ class FontFamily {
 const vm = new ViewModel();
 vm.isMobile(navigator.userAgent.match(/iPhone|Android.+Mobile/));
 vm.backgroundImage.subscribe(function(newValue){
-    changeBackgroundColorAlpha(".header", newValue !== '' ? 0.9375 : 1.0);
-    changeBackgroundColorAlpha(".settings", newValue !== '' ? 0.9375 : 1.0);
-    changeBackgroundColorAlpha(".main", newValue !== '' ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-column", newValue !== '' ? 0.0 : 1.0);
-    changeBackgroundColorAlpha(".column_box", newValue !== '' ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".selected_column", newValue !== '' ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-column-projects-project", newValue !== '' ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-todo", newValue !== '' ? 0.0 : 1.0);
-    changeBackgroundColorAlpha(".main-todo-result", newValue !== '' ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-todo-body-tasks-task", newValue !== '' ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-todo-body-complete_task_button", newValue !== '' ? 0.75 : 1.0);
-    changeBackgroundColorAlpha(".main-todo-body-complete_tasks, .main-todo-body-incomplete_tasks", newValue !== '' ? 0.75 : 1.0);
+    for(const item of BACKGROUND_COLOR_ALPHA){
+        //背景色透過率
+        const alpha = (newValue !== '') ? item.alpha : 1.0;
+        //CSSスタイル background-color に"!important"を追記するかどうか？
+        const important = ('important' in item) ? item.important : false;
+        //背景色透過率を変更する
+        changeBackgroundColorAlpha(item.selector, alpha, important);
+    }
 });
 ko.applyBindings(vm);
 
@@ -549,7 +560,8 @@ function inputProject(text){
 }
 
 //プロジェクトの色変更
-function changeProjectColor(project, event){
+function changeProjectColor(object, event){
+    const project = object instanceof Project ? object : vm.selectedColumn();
     const color = event.target.value;
     $.ajax("./post.php",
         {
@@ -812,7 +824,7 @@ function getCssRules(selector){
 }
 
 //CSSセレクタの背景色透明度を設定する
-function changeBackgroundColorAlpha(selector, alpha){
+function changeBackgroundColorAlpha(selector, alpha, important){
     const cssRules = getCssRules(selector);
     for(const cssRule of cssRules){
         const style = cssRule.style;
@@ -833,7 +845,8 @@ function changeBackgroundColorAlpha(selector, alpha){
         }else if(rgba.length === 4){
             rgba[3] = alpha;
         }
-        style.backgroundColor = `rgba(${rgba[0]}, ${rgba[1]}, ${rgba[2]}, ${rgba[3]})`;
+        const options = important ? '!important' : '';
+        style.backgroundColor = `rgba(${rgba[0]}, ${rgba[1]}, ${rgba[2]}, ${rgba[3]}) ${options}`;
     }
 }
 


### PR DESCRIPTION
Pull Request #43 より @doamomo 様のコメント( https://github.com/doamomo/todoApp/pull/43#issuecomment-952627931 )を引用致します。
> あくまで案ですが、タスク一覧タイトルのラベルの大きさを現状より1.5倍ほど（適当です）大きくすることで、よりタップしやすくなるかもしれないと考えました。

コメント頂きましてありがとうございます。

大変恐縮ですが、件名に記載の通り、「タスク一覧ラベルのタップでプロジェクト色変更対応」を行いました。
対応内容は以下の通りとなっております。
1. タスク一覧ラベルのタップでプロジェクト色変更対応を行いました。また、ラベルの大きさが1.4倍となるよう調整致しました。
下図の赤枠の箇所(タスク一覧ラベル)をタップすることにより、プロジェクト色選択が可能となるよう変更致しました。<br /><img width="300" src="https://user-images.githubusercontent.com/90094327/139564708-9eb39688-96f3-402d-b0e8-319908bd48b7.png">
2. タスク一覧アイコンの位置を調整致しました。
上寄りになっておりましたが、中央揃えとなるよう調整致しました。<br /><img height="300" src="https://user-images.githubusercontent.com/90094327/139565006-8bfbf1e2-dcfd-4a41-8c96-43daaf5017ee.png">
3. プロジェクト一覧の選択色が正しく表示されない不具合を修正致しました(Pull Request #47 の不具合になります、お手数をお掛けいたしました)。
CSSクラスの背景色スタイルに"!important"を追記致しました。<br /><img height="300" src="https://user-images.githubusercontent.com/90094327/139565163-f06db56f-83ed-4bc7-870c-54837740d438.png">
4. main.js の vm.backgroundImage.subscribe と記載している箇所の実装見直しを行いました。
main.jsの先頭に BACKGROUND_COLOR_ALPHA 定数を追加し、その定数により背景色透過率(背景画像ありの場合)を設定するよう変更致しました。

お手数をお掛け致しますが、ご確認のほど、よろしくお願い致します。