### PR TITLE
スマホでの利便性向上のためハンバーガー表示位置変更

### DIFF
--- a/todo/srcFolder/index.php
+++ b/todo/srcFolder/index.php
@@ -18,7 +18,10 @@
             backgroundImage: backgroundImage() !== null ? 'url(' + backgroundImage() + ')' : 'none',
             'font-family': selectedFontFamily() }">
         <div class="header">
-            <i class="icon-person material-icons">person</i>
+            <i class="material-icons" data-bind="
+                click: isMobile() ? function(){displayColumn(!displayColumn());return true;} : function(){return true},
+                css: isMobile() ? 'hamburger' : 'icon-person',
+                text: isMobile() ? 'menu' : 'person'"></i>
             <p class="user">みんまるたすく ver1.7.0</p>
             <i class="icon-settings material-icons" data-bind="
                 click: function(){displaySettings(!displaySettings())},
@@ -46,7 +49,6 @@
             <i class="material-icons settings-icons" data-bind="click: function(){updateBackgroundImage('')}">delete</i>
         </div>
         <div class="main" data-bind="style: { height: isMobile() ? 'auto' : '450px'}">
-            <i class="material-icons hamburger" data-bind="visible: isMobile, click: function(){displayColumn(!displayColumn())}">menu</i>
             <div class="main-column" data-bind="visible: displayColumn">
                 <div data-bind="foreach: columns">
                     <div class="column_box" data-bind="click: displayTasks, css: { selected_column: $root.selectedColumn() === $data }">

--- a/todo/srcFolder/main.css
+++ b/todo/srcFolder/main.css
@@ -207,7 +207,11 @@
 }
 
 .hamburger {
-  position: fixed;
+  position: relative;
+  top: 0px;
+  left: 20px;
+  transform: scale(1.5);
+  margin-right: 40px;
 }
 
 .settings-icons {


### PR DESCRIPTION
大変恐縮ですが、あくまでもご提案という形になりますが、スマホでの利便性向上のためハンバーガーボタンの表示位置変更を行いました(「今日」とハンバーガーボタンの押し間違いが頻発してしまったためです)。
下図のようになっております(iPhone SE(第2世代)とAndroid(Chrome)にて動作確認済みです)。

<img width="300" src="https://user-images.githubusercontent.com/90094327/139991528-f0a5aff1-e406-4d0d-b8a1-16df51df9802.png">

お手数をお掛け致しますが、ご確認のほど、よろしくお願い致します。
提案内容および実装コードに問題がないようでしたら、マージして頂けますと幸いです。
他に良い実装方法がございましたら、コメント頂けますと幸いです。