### PR TITLE
パフォーマンス改善のため背景画像キャッシュ対応

### DIFF
--- a/todo/srcFolder/index.php
+++ b/todo/srcFolder/index.php
@@ -15,7 +15,7 @@
 <body data-bind="style: { width: isMobile() ? '100%' : '800px', margin: isMobile() ? '0' : '8px' }">
     <div class="bodyDiv" data-bind="
         style: {
-            backgroundImage: backgroundImage() !== null ? 'url(' + backgroundImage() + ')' : 'none',
+            backgroundImage: backgroundImageHash() !== null ? `url(./post.php?todo=background-image&hash=${backgroundImageHash()})` : 'unset',
             'font-family': selectedFontFamily() }">
         <div class="header">
             <i class="material-icons" data-bind="
@@ -46,7 +46,7 @@
                 <span data-bind="text: `MAX:${imageFileMaxSize()}B`"></span>
                 <input type="file" class="settings-background-image-file" accept="image/*" data-bind="event: { change: changeBackgroundImage }"/>
             </label>
-            <i class="material-icons settings-icons" data-bind="click: function(){updateBackgroundImage('')}">delete</i>
+            <i class="material-icons settings-icons" data-bind="click: function(){updateBackgroundImage(null)}">delete</i>
         </div>
         <div class="main" data-bind="style: { height: isMobile() ? 'auto' : '450px'}">
             <div class="main-column" data-bind="visible: displayColumn">

--- a/todo/srcFolder/main.js
+++ b/todo/srcFolder/main.js
@@ -98,7 +98,7 @@ class ViewModel {
  
     //背景画像
     imageFileMaxSize = ko.observable('0');
-    backgroundImage = ko.observable('');
+    backgroundImageHash = ko.observable(null);
 
     //フォント
     availableFontFamilies = [
@@ -252,10 +252,10 @@ class FontFamily {
 //ビューにビューモデルをバインド
 const vm = new ViewModel();
 vm.isMobile(navigator.userAgent.match(/iPhone|Android.+Mobile/));
-vm.backgroundImage.subscribe(function(newValue){
+vm.backgroundImageHash.subscribe(function(newValue){
     for(const item of BACKGROUND_COLOR_ALPHA){
         //背景色透過率
-        const alpha = (newValue !== '') ? item.alpha : 1.0;
+        const alpha = (newValue !== null) ? item.alpha : 1.0;
         //CSSスタイル background-color に"!important"を追記するかどうか？
         const important = ('important' in item) ? item.important : false;
         //背景色透過率を変更する
@@ -794,7 +794,7 @@ function changeFontFamily(context, event){
             dataType: "json"
         }
     ).done(function(data){
-        if(data !== true){
+        if(data === null || data["result"] !== true){
             alert("フォントを変更できません");
             return;
         }
@@ -863,11 +863,11 @@ function updateBackgroundImage(imageData){
             dataType: "json"
         }
     ).done(function(data){
-        if(data !== true){
+        if(data === null || data["result"] !== true){
             alert("背景画像を変更できません");
             return;
         }
-        vm.backgroundImage(imageData);
+        vm.backgroundImageHash(data["hash"]);
     }).fail(function(XMLHttpRequest, status, e){
         alert("背景画像を変更できません\n" + e);
     });
@@ -902,7 +902,6 @@ function initSkin(){
         if(keyValueArray === null){
             return;
         }
-        let imageData = [];
         for(const row of keyValueArray){
             const key = row["key"];
             const value = row["value"];
@@ -913,13 +912,10 @@ function initSkin(){
                 case "image-file-max-size":
                     vm.imageFileMaxSize(value);
                     break;
-                case "background-image":
-                    imageData.push(value);
+                case "background-image-hash":
+                    vm.backgroundImageHash(value);
                     break;
             }
-        }
-        if(imageData.length>0){
-            vm.backgroundImage(imageData.join(''));
         }
         vm.displaySettingsIcon(true);
     }).fail(function(XMLHttpRequest, status, e){

--- a/todo/srcFolder/post.php
+++ b/todo/srcFolder/post.php
@@ -3,6 +3,18 @@
 include_once('./config/DB.php');
 include_once('./SQL.php');
 
+//GETパラメータ確認 (背景画像データ取得の場合のみ)
+if (isset($_GET['todo']) && $_GET['todo'] === 'background-image') {
+    $result = SQL::getBackGroundImage();
+    if ($result === null) {
+        die();
+    }
+    header("Content-type: ${result['mediatype']}");
+    header("Expires: Fri, 31 Dec 9999 23:59:59 GMT");
+    echo $result['data'];
+    exit;
+}
+
 //Ajaxで送られたtodoパラメータに応じた処理を行う
 switch ($_POST['todo']) {
     case "insertProject":


### PR DESCRIPTION
大変恐縮ですが、パフォーマンス改善のため背景画像キャッシュ対応を行いました。
この改修対応により、背景画像ありの場合に通信量が大幅削減されます。

検証に用いた画像はパブリックドメインQ様( https://publicdomainq.net/ )より取得しました下図のものです。
![image](https://user-images.githubusercontent.com/90094327/140275636-5ff20ead-746f-4133-ac9f-4054c63baaa4.png)

通信量の確認はGoogle Chromeのデベロッパーツール [ネットワーク]タブにて行っております。

1. 改修対応前
サンプル画像を背景画像として選択した場合、キャッシュなしでは2.5MB、キャッシュありでは2.2MBの通信量がありました。
![image](https://user-images.githubusercontent.com/90094327/140274898-3d520fe8-157d-450a-b263-4091c988833b.png)

2. 改修対応後
主にSQL.php, post.phpを改修しております。
以下のようなCSSスタイルを指定することにより、post.phpから画像バイナリデータを取得できるよう対応しております。ここでの'hash'パラメータはDBへ登録した背景画像データのハッシュ値(SHA256)です。
このハッシュ値は画像データのわずかな変更でも大きく変わるため、これまでに表示していた画像と同一のものであるかどうかの判定に用いております(判定はWebブラウザが自動的に行います)。
同一あればキャッシュから取得しようとし、同一でなければpost.phpを介して画像データを取得します。
`background-image: url("./post.php?todo=background-image&hash=9f4c2b7a91fed79639ff10a34dee2a530f3caa67b4b277eac6492147f58738c3");`<br />
改修後は、キャッシュなしで1.9MB、キャッシュありで0.013MBの通信量がありました。大幅な通信量の削減となっており、素早く背景画像が表示されるようになりました。
![image](https://user-images.githubusercontent.com/90094327/140275234-05ae207f-2f69-48ba-bd6b-9f1990edb52e.png)

お手数をお掛け致しますが、ご確認のほど、よろしくお願い致します。