### PR TITLE
iPhone(Safari)におけるリプレイ時のsound再生遅延修正

### DIFF
--- a/todo/srcFolder/main.js
+++ b/todo/srcFolder/main.js
@@ -475,6 +475,8 @@ function clickTaskStatus(task){
     const project_id = (vm.selectedColumn() instanceof Project) ? vm.selectedColumn().id : null;
     //タスクを完了状態にしたときのみ効果音を鳴らす
     if(!task.isCompleted && soundNum !== 0){
+        const AudioContext = window.AudioContext || window.webkitAudioContext;
+        const audioCtx = new AudioContext();
         sound.play();
     }
     //Ajax


### PR DESCRIPTION
大変恐縮ですが、iPhone(Safari)におけるリプレイ時のsound再生遅延修正を行いました。

以下のWebページを参考にコードを追加する形で修正を行いました。
1. MDN Web Docs
https://developer.mozilla.org/ja/docs/Web/API/AudioContext#%E4%BE%8B
2. Stack Overflow
https://stackoverflow.com/questions/9811429/html5-audio-tag-on-safari-has-a-delay/54119854#54119854

sound.play()直前に追加したコード:
```JavaScript
const AudioContext = window.AudioContext || window.webkitAudioContext;
const audioCtx = new AudioContext();
```

修正しました結果、以下動画のように修正されております。

※注：音量注意です。再生時はミュート解除をお願い致します。

https://user-images.githubusercontent.com/90094327/140446262-ab6ea1ce-09fb-4e33-83f1-1668c62f57ab.mp4

お手数をお掛け致しますが、ご確認のほど、よろしくお願い致します。