### PR TITLE
クラス図 ViewModeクラス フィールドグループ化

### DIFF
--- a/todo/class.puml
+++ b/todo/class.puml
@@ -1,14 +1,18 @@
 @startuml
 class ViewModel {
+  .. Column / Project ..
+  {field} +displayColumn : ko.observable(Boolean)
   +columns : Column[]
   {field} +projects : ko.observableArray(Project)
-  {field} +incompleteTasks : ko.observableArray(Task)
-  {field} +completedTasks : ko.observableArray(Task)
-  {field} +displayColumn : ko.observable(Boolean)
-  {field} +isMobile : ko.observable(Boolean)
-  {field} +openCompleteTaskFlag : ko.observable(Number)
   {field} +selectedColumn : ko.observable(AbstractColumn)
   {field} +renameProject : ko.observable(Project)
+  .. Task ..
+  {field} +incompleteTasks : ko.observableArray(Task)
+  {field} +completedTasks : ko.observableArray(Task)
+  {field} +openCompleteTaskFlag : ko.observable(Number)
+  .. Environment ..
+  {field} +isMobile : ko.observable(Boolean)
+  .. User Setting ..
   {field} +displaySettings : ko.observable(Boolean)
   {field} +displaySettingsIcon : ko.observable(Boolean)
   {field} +imageFileMaxSize : ko.observable(String)


### PR DESCRIPTION
大変恐縮ですが、main.js ViewModelクラスにつきまして、フィールドの数が増えましたのでクラス図の表現を変更致しました。

下図のようにグループ分けを行っております。
![class](https://user-images.githubusercontent.com/90094327/142745250-01490b60-67d7-42dd-8aae-65827587d29a.png)

お手数をお掛け致しますが、ご確認のほど、よろしくお願い致します。